### PR TITLE
attribute "type" not required in HTML5

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,14 +3,14 @@
   <head>
     <meta charset="UTF-8">
     <title>memory</title>
-    <script src="libraries/p5.js" type="text/javascript"></script>
+    <script src="libraries/p5.js"></script>
 
-    <script src="libraries/p5.dom.js" type="text/javascript"></script>
-    <script src="libraries/p5.sound.js" type="text/javascript"></script>
+    <script src="libraries/p5.dom.js"></script>
+    <script src="libraries/p5.sound.js"></script>
 
-    <script src="sketch.js" type="text/javascript"></script>
-    <script src="card.js" type="text/javascript"></script>
-    <script src="player.js" type="text/javascript"></script>
+    <script src="sketch.js"></script>
+    <script src="card.js"></script>
+    <script src="player.js"></script>
 
     <style> body {padding: 0; margin: 0;} canvas {vertical-align: top;} </style>
   </head>


### PR DESCRIPTION
The type attribute is not required. JavaScript is the default scripting language in HTML5.